### PR TITLE
feat: add cdk-erigon version parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.19 as builder
 WORKDIR /opt/cdk-erigon
-RUN git clone --branch zkevm https://github.com/0xPolygonHermez/cdk-erigon . \
+ARG CDK_ERIGON_VERSION
+RUN git clone --branch ${CDK_ERIGON_VERSION} https://github.com/0xPolygonHermez/cdk-erigon . \
   && make cdk-erigon
 
 FROM debian:bookworm-slim

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,8 @@
 # User configuration for a CDK-Erigon node.
 
+# The version of the CDK-Erigon node to run.
+cdk_erigon_version: zkevm
+
 # The zkEVM Hermez network to join.
 # {mainnet|cardona|bali}
 chain: cardona

--- a/main.star
+++ b/main.star
@@ -3,6 +3,7 @@ blockscout = import_module("github.com/leovct/kurtosis-blockscout/main.star")
 
 def run(
     plan,
+    cdk_erigon_version="zkevm",
     chain="cardona",
     datadir="/var/lib/cdk-erigon",
     zkevm_rpc_rate_limit=250,
@@ -21,7 +22,7 @@ def run(
         zkevm_l1_query_delay,
         zkevm_l1_first_block,
     )
-    erigon_node_host = start_cdk_erigon_node(plan, config)
+    erigon_node_host = start_cdk_erigon_node(plan, cdk_erigon_version, config)
 
     rpc_http_url = "http://{}:8545".format(erigon_node_host)
     blockscout.run(plan, rpc_http_url)
@@ -81,11 +82,14 @@ def create_cdk_erigon_node_config(
     return result.files_artifacts[0]
 
 
-def start_cdk_erigon_node(plan, config):
+def start_cdk_erigon_node(plan, cdk_erigon_version, config):
     erigon_node = plan.add_service(
         name="cdk-erigon-node",
         config=ServiceConfig(
             image=ImageBuildSpec(image_name="cdk-erigon", build_context_dir="."),
+            build_args={
+                "CDK_ERIGON_VERSION": cdk_erigon_version,
+            },
             files={"/etc/cdk-erigon": config},
             ports={"http_rpc": PortSpec(8545, application_protocol="http")},
             cmd=["--config=/etc/cdk-erigon/config.yaml", "--maxpeers=0"],

--- a/main.star
+++ b/main.star
@@ -52,10 +52,13 @@ def start_node(plan, cdk_erigon_version, config, persistent, datadir):
     service = plan.add_service(
         name="cdk-erigon-node",
         config=ServiceConfig(
-            image=ImageBuildSpec(image_name="cdk-erigon", build_context_dir="."),
-            build_args={
-                "CDK_ERIGON_VERSION": cdk_erigon_version,
-            },
+            image=ImageBuildSpec(
+                image_name="cdk-erigon",
+                build_context_dir=".",
+                build_args={
+                    "CDK_ERIGON_VERSION": cdk_erigon_version,
+                },
+            ),
             files=files,
             ports={"http_rpc": PortSpec(8545, application_protocol="http")},
             cmd=["--config=/etc/cdk-erigon/config.yaml", "--maxpeers=0"],


### PR DESCRIPTION
Resolves #1 

Added a new argument `cdk_erigon_version`. It is possible to specify any commit, tag or release identifier. The default value is `zkevm`, which means that the Docker file will try to build the latest version of the cdk-erigon repository since all development is done on the `zkevm` branch. 

Note: this PR can only be merged after Kurtosis `ServiceConfig` support for build arguments has been integrated and published in kurtosis.